### PR TITLE
[[feat]] Add mediodia and finde

### DIFF
--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -77,7 +77,7 @@ DayBetweenRegex: !nestedRegex
 SpecialYearPrefixes: !simpleRegex
   def: ((del\s+)?calend[aá]rio|(?<special>fiscal|escolar))
 OneWordPeriodRegex: !nestedRegex
-  def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?((({RelativeRegex}\s+){DateUnitRegex}(\s+{AfterNextSuffixRegex})?)|{DateUnitRegex}(\s+{AfterNextSuffixRegex}))|va\s+de\s+{DateUnitRegex})
+  def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|finde(\\s+{AfterNextSuffixRegex})?|((la|el)\s+)?((({RelativeRegex}\s+){DateUnitRegex}(\s+{AfterNextSuffixRegex})?)|{DateUnitRegex}(\s+{AfterNextSuffixRegex}))|va\s+de\s+{DateUnitRegex})
   references: [MonthRegex, RelativeRegex, OfPrepositionRegex, AfterNextSuffixRegex,DateUnitRegex]
 MonthWithYearRegex: !nestedRegex
   def: \b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\s+)?({MonthRegex})(\s+|(\s*[,-]\s*))((de|del|de la)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b
@@ -894,6 +894,7 @@ MorningTermList: !list
 AfternoonTermList: !list
   types: [ string ]
   entries:
+    - mediodia
     - pasado mediodia
     - pasado el mediodia
 EveningTermList: !list
@@ -945,6 +946,7 @@ MonthToDateTerms: !list
 WeekendTerms: !list
   types: [ string ]
   entries:
+    - finde
     - fin de semana
 WeekTerms: !list
   types: [ string ]

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -77,7 +77,7 @@ DayBetweenRegex: !nestedRegex
 SpecialYearPrefixes: !simpleRegex
   def: ((del\s+)?calend[aá]rio|(?<special>fiscal|escolar))
 OneWordPeriodRegex: !nestedRegex
-  def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|finde(\\s+{AfterNextSuffixRegex})?|((la|el)\s+)?((({RelativeRegex}\s+){DateUnitRegex}(\s+{AfterNextSuffixRegex})?)|{DateUnitRegex}(\s+{AfterNextSuffixRegex}))|va\s+de\s+{DateUnitRegex})
+  def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?finde(\s+{AfterNextSuffixRegex})?|((la|el)\s+)?((({RelativeRegex}\s+)({DateUnitRegex}|finde)(\s+{AfterNextSuffixRegex})?)|((la|el)\s+)?({DateUnitRegex}|finde)(\s+{AfterNextSuffixRegex}))|va\s+de\s+({DateUnitRegex}|finde))
   references: [MonthRegex, RelativeRegex, OfPrepositionRegex, AfterNextSuffixRegex,DateUnitRegex]
 MonthWithYearRegex: !nestedRegex
   def: \b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\s+)?({MonthRegex})(\s+|(\s*[,-]\s*))((de|del|de la)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b
@@ -829,7 +829,7 @@ RelativeDurationUnitRegex: !simpleRegex
 ReferencePrefixRegex: !simpleRegex
   def: (mism[ao]|aquel)\b
 ReferenceDatePeriodRegex: !nestedRegex
-  def: \b{ReferencePrefixRegex}\s+({DateUnitRegex}|fin\s+de\s+semana)\b
+  def: \b{ReferencePrefixRegex}\s+({DateUnitRegex}|fin\s+de\s+semana|finde)\b
   references: [ReferencePrefixRegex, DateUnitRegex]
 FromToRegex: !simpleRegex
   # TODO: change to Spanish according to corresponding Regex
@@ -947,8 +947,9 @@ MonthToDateTerms: !list
 WeekendTerms: !list
   types: [ string ]
   entries:
-    - el fin de semana
+    - el finde
     - finde
+    - el fin de semana
     - fin de semana
 WeekTerms: !list
   types: [ string ]

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/datetimeperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/datetimeperiod_parser_config.py
@@ -216,7 +216,8 @@ class SpanishDateTimePeriodParserConfiguration(DateTimePeriodParserConfiguration
             time_str = 'TMO'
             begin_hour = 8
             end_hour = Constants.HALF_DAY_HOUR_COUNT
-        elif 'pasado mediodia' in trimmed_source or 'pasado el mediodia' in trimmed_source:
+        elif ('mediodia' in trimmed_source or 'pasado mediodia' in trimmed_source or
+              'pasado el mediodia' in trimmed_source):
             time_str = 'TAF'
             begin_hour = Constants.HALF_DAY_HOUR_COUNT
             end_hour = 16

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/spanish_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/spanish_date_time.py
@@ -46,7 +46,7 @@ class SpanishDateTime:
     MonthFrontBetweenRegex = f'\\b{MonthSuffixRegex}\\s+((entre|entre\\s+el)\\s+)({DayRegex})\\s*{RangeConnectorRegex}\\s*({DayRegex})((\\s+|\\s*,\\s*)(en\\s+|del\\s+|de\\s+)?{YearRegex})?\\b'
     DayBetweenRegex = f'\\b((entre|entre\\s+el)\\s+)({DayRegex})\\s*{RangeConnectorRegex}\\s*({DayRegex})\\s+{MonthSuffixRegex}((\\s+|\\s*,\\s*)(en\\s+|del\\s+|de\\s+)?{YearRegex})?\\b'
     SpecialYearPrefixes = f'((del\\s+)?calend[aá]rio|(?<special>fiscal|escolar))'
-    OneWordPeriodRegex = f'\\b(((((la|el)\\s+)?mes\\s+(({OfPrepositionRegex})\\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\\s+))?({MonthRegex})|((la|el)\\s+)?((({RelativeRegex}\\s+){DateUnitRegex}(\\s+{AfterNextSuffixRegex})?)|{DateUnitRegex}(\\s+{AfterNextSuffixRegex}))|va\\s+de\\s+{DateUnitRegex})'
+    OneWordPeriodRegex = f'\\b(((((la|el)\\s+)?mes\\s+(({OfPrepositionRegex})\\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\\s+))?({MonthRegex})|finde(\\\\s+{AfterNextSuffixRegex})?|((la|el)\\s+)?((({RelativeRegex}\\s+){DateUnitRegex}(\\s+{AfterNextSuffixRegex})?)|{DateUnitRegex}(\\s+{AfterNextSuffixRegex}))|va\\s+de\\s+{DateUnitRegex})'
     MonthWithYearRegex = f'\\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\\s+)?({MonthRegex})(\\s+|(\\s*[,-]\\s*))((de|del|de la)\\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\\s+año))\\b'
     MonthNumWithYearRegex = f'\\b(({YearRegex}(\\s*?)[/\\-\\.~](\\s*?){MonthNumRegex})|({MonthNumRegex}(\\s*?)[/\\-\\.~](\\s*?){YearRegex}))\\b'
     WeekOfMonthRegex = f'(?<wom>(la\\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|[uú]ltima)\\s+semana\\s+{MonthSuffixRegex})'
@@ -458,7 +458,7 @@ class SpanishDateTime:
     AmbiguityFiltersDict = dict([("null", "null")])
     EarlyMorningTermList = [r'madrugada']
     MorningTermList = [r'mañana']
-    AfternoonTermList = [r'pasado mediodia', r'pasado el mediodia']
+    AfternoonTermList = [r'mediodia', r'pasado mediodia', r'pasado el mediodia']
     EveningTermList = [r'tarde']
     NightTermList = [r'noche']
     SameDayTerms = [r'hoy', r'el dia']
@@ -468,7 +468,7 @@ class SpanishDateTime:
     MinusTwoDayTerms = [r'anteayer', r'dia antes de ayer']
     MonthTerms = [r'mes', r'meses']
     MonthToDateTerms = [r'mes a la fecha', r'meses a la fecha']
-    WeekendTerms = [r'fin de semana']
+    WeekendTerms = [r'finde', r'fin de semana']
     WeekTerms = [r'semana']
     YearTerms = [r'año', r'años']
     YearToDateTerms = [r'año a la fecha', r'años a la fecha']

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/spanish_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/spanish_date_time.py
@@ -46,7 +46,7 @@ class SpanishDateTime:
     MonthFrontBetweenRegex = f'\\b{MonthSuffixRegex}\\s+((entre|entre\\s+el)\\s+)({DayRegex})\\s*{RangeConnectorRegex}\\s*({DayRegex})((\\s+|\\s*,\\s*)(en\\s+|del\\s+|de\\s+)?{YearRegex})?\\b'
     DayBetweenRegex = f'\\b((entre|entre\\s+el)\\s+)({DayRegex})\\s*{RangeConnectorRegex}\\s*({DayRegex})\\s+{MonthSuffixRegex}((\\s+|\\s*,\\s*)(en\\s+|del\\s+|de\\s+)?{YearRegex})?\\b'
     SpecialYearPrefixes = f'((del\\s+)?calend[aá]rio|(?<special>fiscal|escolar))'
-    OneWordPeriodRegex = f'\\b(((((la|el)\\s+)?mes\\s+(({OfPrepositionRegex})\\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\\s+))?({MonthRegex})|finde(\\\\s+{AfterNextSuffixRegex})?|((la|el)\\s+)?((({RelativeRegex}\\s+){DateUnitRegex}(\\s+{AfterNextSuffixRegex})?)|{DateUnitRegex}(\\s+{AfterNextSuffixRegex}))|va\\s+de\\s+{DateUnitRegex})'
+    OneWordPeriodRegex = f'\\b(((((la|el)\\s+)?mes\\s+(({OfPrepositionRegex})\\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\\s+))?({MonthRegex})|((la|el)\\s+)?finde(\\s+{AfterNextSuffixRegex})?|((la|el)\\s+)?((({RelativeRegex}\\s+)({DateUnitRegex}|finde)(\\s+{AfterNextSuffixRegex})?)|((la|el)\\s+)?({DateUnitRegex}|finde)(\\s+{AfterNextSuffixRegex}))|va\\s+de\\s+({DateUnitRegex}|finde))'
     MonthWithYearRegex = f'\\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\\s+)?({MonthRegex})(\\s+|(\\s*[,-]\\s*))((de|del|de la)\\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\\s+año))\\b'
     MonthNumWithYearRegex = f'\\b(({YearRegex}(\\s*?)[/\\-\\.~](\\s*?){MonthNumRegex})|({MonthNumRegex}(\\s*?)[/\\-\\.~](\\s*?){YearRegex}))\\b'
     WeekOfMonthRegex = f'(?<wom>(la\\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|[uú]ltima)\\s+semana\\s+{MonthSuffixRegex})'
@@ -437,7 +437,7 @@ class SpanishDateTime:
     RestOfDateRegex = f'\\bresto\\s+((del|de)\\s+)?((la|el|est[ae])\\s+)?(?<duration>semana|mes|año|decada)(\\s+actual)?\\b'
     RelativeDurationUnitRegex = f'^[\\.]'
     ReferencePrefixRegex = f'(mism[ao]|aquel)\\b'
-    ReferenceDatePeriodRegex = f'\\b{ReferencePrefixRegex}\\s+({DateUnitRegex}|fin\\s+de\\s+semana)\\b'
+    ReferenceDatePeriodRegex = f'\\b{ReferencePrefixRegex}\\s+({DateUnitRegex}|fin\\s+de\\s+semana|finde)\\b'
     FromToRegex = f'\\b(from).+(to)\\b.+'
     SingleAmbiguousMonthRegex = f'^(the\\s+)?(may|march)$'
     UnspecificDatePeriodRegex = f'^[.]'
@@ -468,7 +468,7 @@ class SpanishDateTime:
     MinusTwoDayTerms = [r'anteayer', r'dia antes de ayer']
     MonthTerms = [r'el mes', r'mes', r'meses']
     MonthToDateTerms = [r'mes a la fecha', r'meses a la fecha']
-    WeekendTerms = [r'finde', r'el fin de semana', r'fin de semana']
+    WeekendTerms = [r'el finde', r'finde', r'el fin de semana', r'fin de semana']
     WeekTerms = [r'la semana', r'semana']
     YearTerms = [r'el año', r'año', r'años']
     YearToDateTerms = [r'año a la fecha', r'años a la fecha']

--- a/Specs/DateTime/Spanish/DatePeriodExtractor.json
+++ b/Specs/DateTime/Spanish/DatePeriodExtractor.json
@@ -2450,6 +2450,19 @@
     ]
   },
   {
+    "Input": "Ya no estaré el finde que viene",
+    "NotSupported": "java",
+    "NotSupportedByDesign": "javascript",
+    "Results": [
+      {
+        "Text": "el finde que viene",
+        "Type": "daterange",
+        "Start": 13,
+        "Length": 18
+      }
+    ]
+  },
+  {
     "Input": "Ya no estaré el último sept",
     "NotSupported": "java",
     "NotSupportedByDesign": "javascript",

--- a/Specs/DateTime/Spanish/DatePeriodExtractor.json
+++ b/Specs/DateTime/Spanish/DatePeriodExtractor.json
@@ -190,6 +190,17 @@
     ]
   },
   {
+    "Input": "Estare afuera este finde",
+    "Results": [
+      {
+        "Text": "este finde",
+        "Type": "daterange",
+        "Start": 14,
+        "Length": 10
+      }
+    ]
+  },
+  {
     "Input": "Estare afuera la tercera semana de este mes",
     "Results": [
       {
@@ -2504,6 +2515,19 @@
     ]
   },
   {
+    "Input": "Ya no estaré este finde",
+    "NotSupported": "java",
+    "NotSupportedByDesign": "javascript",
+    "Results": [
+      {
+        "Text": "este finde",
+        "Type": "daterange",
+        "Start": 13,
+        "Length": 10
+      }
+    ]
+  },
+  {
     "Input": "Ya no estaré la tercera semana de este mes",
     "NotSupported": "java",
     "NotSupportedByDesign": "javascript",
@@ -3220,6 +3244,19 @@
         "Type": "daterange",
         "Start": 10,
         "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Me iré en el finde",
+    "NotSupported": "java",
+    "NotSupportedByDesign": "javascript",
+    "Results": [
+      {
+        "Text": "el finde",
+        "Type": "daterange",
+        "Start": 10,
+        "Length": 8
       }
     ]
   },

--- a/Specs/DateTime/Spanish/DatePeriodParser.json
+++ b/Specs/DateTime/Spanish/DatePeriodParser.json
@@ -2199,7 +2199,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "java, python",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript",
     "Results": [
       {
@@ -2222,15 +2222,42 @@
     ]
   },
   {
+    "Input": "el finde",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java",
+    "NotSupportedByDesign": "javascript",
+    "Results": [
+      {
+        "Text": "el finde",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W45-WE",
+          "FutureResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          }
+        },
+        "Start": 0,
+        "Length": 8
+      }
+    ]
+  },
+  {
     "Input": "este fin de semana",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet, java, python",
+    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript",
     "Results": [
       {
-        "Text": "",
+        "Text": "este fin de semana",
         "Type": "daterange",
         "Value": {
           "Timex": "2016-W45-WE",
@@ -2253,7 +2280,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet, java, python",
+    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript",
     "Results": [
       {
@@ -2685,7 +2712,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet, java, python",
+    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript",
     "Results": [
       {
@@ -2712,7 +2739,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet, java, python",
+    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript",
     "Results": [
       {
@@ -5155,6 +5182,34 @@
         },
         "Start": 32,
         "Length": 57
+      }
+    ]
+  },
+  {
+    "Input": "Claro, vamos a hablar por skype el finde que viene",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
+    "NotSupported": "dotnet, java",
+    "NotSupportedByDesign": "javascript",
+    "Results": [
+      {
+        "Text": "el finde que viene",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2017-W46-WE",
+          "Mod": "",
+          "FutureResolution": {
+            "startDate": "2017-11-18",
+            "endDate": "2017-11-20"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-18",
+            "endDate": "2017-11-20"
+          }
+        },
+        "Start": 32,
+        "Length": 49
       }
     ]
   },

--- a/Specs/DateTime/Spanish/DatePeriodParser.json
+++ b/Specs/DateTime/Spanish/DatePeriodParser.json
@@ -756,6 +756,31 @@
     ]
   },
   {
+    "Input": "Estare afuera el finde",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "el finde",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W45-WE",
+          "FutureResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          }
+        },
+        "Start": 14,
+        "Length": 18
+      }
+    ]
+  },
+  {
     "Input": "Estare afuera este fin de semana",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
@@ -777,6 +802,31 @@
         },
         "Start": 14,
         "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Estare afuera este finde",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "este finde",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W45-WE",
+          "FutureResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          }
+        },
+        "Start": 14,
+        "Length": 10
       }
     ]
   },

--- a/Specs/DateTime/Spanish/DateTimePeriodParser.json
+++ b/Specs/DateTime/Spanish/DateTimePeriodParser.json
@@ -2889,5 +2889,205 @@
         "Length": 21
       }
     ]
+  },
+  {
+    "Input": "hoy a mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-12-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "hoy a mediodia",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2019-12-07TAF",
+          "FutureResolution": {
+            "startDateTime": "2019-12-07 12:00:00",
+            "endDateTime": "2019-12-07 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2019-12-07 12:00:00",
+            "endDateTime": "2019-12-07 16:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "hoy mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-12-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "hoy mediodia",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2019-12-07TAF",
+          "FutureResolution": {
+            "startDateTime": "2019-12-07 12:00:00",
+            "endDateTime": "2019-12-07 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2019-12-07 12:00:00",
+            "endDateTime": "2019-12-07 16:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "hoy pasado mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-12-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "hoy pasado mediodia",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2019-12-07TAF",
+          "FutureResolution": {
+            "startDateTime": "2019-12-07 12:00:00",
+            "endDateTime": "2019-12-07 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2019-12-07 12:00:00",
+            "endDateTime": "2019-12-07 16:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "hoy pasado el mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-12-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "hoy pasado el mediodia",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2019-12-07TAF",
+          "FutureResolution": {
+            "startDateTime": "2019-12-07 12:00:00",
+            "endDateTime": "2019-12-07 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2019-12-07 12:00:00",
+            "endDateTime": "2019-12-07 16:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "ayer a mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-12-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "ayer a mediodia",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2019-12-06TAF",
+          "FutureResolution": {
+            "startDateTime": "2019-12-06 12:00:00",
+            "endDateTime": "2019-12-06 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2019-12-06 12:00:00",
+            "endDateTime": "2019-12-06 16:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "ayer mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-12-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "ayer mediodia",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2019-12-06TAF",
+          "FutureResolution": {
+            "startDateTime": "2019-12-06 12:00:00",
+            "endDateTime": "2019-12-06 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2019-12-06 12:00:00",
+            "endDateTime": "2019-12-06 16:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "ayer pasado mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-12-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "ayer pasado mediodia",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2019-12-06TAF",
+          "FutureResolution": {
+            "startDateTime": "2019-12-06 12:00:00",
+            "endDateTime": "2019-12-06 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2019-12-06 12:00:00",
+            "endDateTime": "2019-12-06 16:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "ayer pasado el mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-12-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "ayer pasado el mediodia",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2019-12-06TAF",
+          "FutureResolution": {
+            "startDateTime": "2019-12-06 12:00:00",
+            "endDateTime": "2019-12-06 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2019-12-06 12:00:00",
+            "endDateTime": "2019-12-06 16:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 23
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Spanish/TimePeriodParser.json
+++ b/Specs/DateTime/Spanish/TimePeriodParser.json
@@ -2020,5 +2020,55 @@
         "Length": 15
       }
     ]
+  },
+  {
+    "Input": "volveré a mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-12-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "mediodia",
+        "Type": "timerange",
+        "Value": {
+          "Timex": "TAF",
+          "FutureResolution": {
+            "startTime": "12:00:00",
+            "endTime": "16:00:00"
+          },
+          "PastResolution": {
+            "startTime": "12:00:00",
+            "endTime": "16:00:00"
+          }
+        },
+        "Start": 10,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "volveré pasado mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-12-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "pasado mediodia",
+        "Type": "timerange",
+        "Value": {
+          "Timex": "TAF",
+          "FutureResolution": {
+            "startTime": "12:00:00",
+            "endTime": "16:00:00"
+          },
+          "PastResolution": {
+            "startTime": "12:00:00",
+            "endTime": "16:00:00"
+          }
+        },
+        "Start": 8,
+        "Length": 15
+      }
+    ]
   }
 ]


### PR DESCRIPTION
**finde**

```
finde que viene
{'start': 0, 'end': 14, 'resolution': {'values': [{'timex': '2020-W31-WE', 'type': 'daterange', 'start': '2020-08-01', 'end': '2020-08-03'}]}, 'text': 'finde que viene', 'type_name': 'datetimeV2.daterange'}
fin de semana que viene
{'start': 0, 'end': 22, 'resolution': {'values': [{'timex': '2020-W31-WE', 'type': 'daterange', 'start': '2020-08-01', 'end': '2020-08-03'}]}, 'text': 'fin de semana que viene', 'type_name': 'datetimeV2.daterange'}
el finde que viene
{'start': 0, 'end': 17, 'resolution': {'values': [{'timex': '2020-W31-WE', 'type': 'daterange', 'start': '2020-08-01', 'end': '2020-08-03'}]}, 'text': 'el finde que viene', 'type_name': 'datetimeV2.daterange'}
el fin de semana que viene
{'start': 0, 'end': 25, 'resolution': {'values': [{'timex': '2020-W31-WE', 'type': 'daterange', 'start': '2020-08-01', 'end': '2020-08-03'}]}, 'text': 'el fin de semana que viene', 'type_name': 'datetimeV2.daterange'}
Me iré en el finde
{'start': 10, 'end': 17, 'resolution': {'values': [{'timex': '2020-W30-WE', 'type': 'daterange', 'start': '2020-07-25', 'end': '2020-07-27'}]}, 'text': 'el finde', 'type_name': 'datetimeV2.daterange'}
Me iré en el fin de semana
{'start': 10, 'end': 25, 'resolution': {'values': [{'timex': '2020-W30-WE', 'type': 'daterange', 'start': '2020-07-25', 'end': '2020-07-27'}]}, 'text': 'el fin de semana', 'type_name': 'datetimeV2.daterange'}
Me iré en el finde que viene
{'start': 10, 'end': 27, 'resolution': {'values': [{'timex': '2020-W31-WE', 'type': 'daterange', 'start': '2020-08-01', 'end': '2020-08-03'}]}, 'text': 'el finde que viene', 'type_name': 'datetimeV2.daterange'}
Me iré en el fin de semana que viene
{'start': 10, 'end': 35, 'resolution': {'values': [{'timex': '2020-W31-WE', 'type': 'daterange', 'start': '2020-08-01', 'end': '2020-08-03'}]}, 'text': 'el fin de semana que viene', 'type_name': 'datetimeV2.daterange'}
Estare afuera el finde
{'start': 14, 'end': 21, 'resolution': {'values': [{'timex': '2020-W30-WE', 'type': 'daterange', 'start': '2020-07-25', 'end': '2020-07-27'}]}, 'text': 'el finde', 'type_name': 'datetimeV2.daterange'}
Estare afuera el fin de semana
{'start': 14, 'end': 29, 'resolution': {'values': [{'timex': '2020-W30-WE', 'type': 'daterange', 'start': '2020-07-25', 'end': '2020-07-27'}]}, 'text': 'el fin de semana', 'type_name': 'datetimeV2.daterange'}
```

**mediodia**
```
hoy a mediodia
{'start': 0, 'end': 13, 'resolution': {'values': [{'timex': '2020-07-24TAF', 'type': 'datetimerange', 'start': '2020-07-24 12:00:00', 'end': '2020-07-24 16:00:00'}]}, 'text': 'hoy a mediodia', 'type_name': 'datetimeV2.datetimerange'}
hoy mediodia
{'start': 0, 'end': 11, 'resolution': {'values': [{'timex': '2020-07-24TAF', 'type': 'datetimerange', 'start': '2020-07-24 12:00:00', 'end': '2020-07-24 16:00:00'}]}, 'text': 'hoy mediodia', 'type_name': 'datetimeV2.datetimerange'}
hoy pasado mediodia
{'start': 0, 'end': 18, 'resolution': {'values': [{'timex': '2020-07-24TAF', 'type': 'datetimerange', 'start': '2020-07-24 12:00:00', 'end': '2020-07-24 16:00:00'}]}, 'text': 'hoy pasado mediodia', 'type_name': 'datetimeV2.datetimerange'}
hoy pasado el mediodia
{'start': 0, 'end': 21, 'resolution': {'values': [{'timex': '2020-07-24TAF', 'type': 'datetimerange', 'start': '2020-07-24 12:00:00', 'end': '2020-07-24 16:00:00'}]}, 'text': 'hoy pasado el mediodia', 'type_name': 'datetimeV2.datetimerange'}
ayer a mediodia
{'start': 0, 'end': 14, 'resolution': {'values': [{'timex': '2020-07-23TAF', 'type': 'datetimerange', 'start': '2020-07-23 12:00:00', 'end': '2020-07-23 16:00:00'}]}, 'text': 'ayer a mediodia', 'type_name': 'datetimeV2.datetimerange'}
ayer mediodia
{'start': 0, 'end': 12, 'resolution': {'values': [{'timex': '2020-07-23TAF', 'type': 'datetimerange', 'start': '2020-07-23 12:00:00', 'end': '2020-07-23 16:00:00'}]}, 'text': 'ayer mediodia', 'type_name': 'datetimeV2.datetimerange'}
ayer pasado mediodia
{'start': 0, 'end': 19, 'resolution': {'values': [{'timex': '2020-07-23TAF', 'type': 'datetimerange', 'start': '2020-07-23 12:00:00', 'end': '2020-07-23 16:00:00'}]}, 'text': 'ayer pasado mediodia', 'type_name': 'datetimeV2.datetimerange'}
ayer pasado el mediodia
{'start': 0, 'end': 22, 'resolution': {'values': [{'timex': '2020-07-23TAF', 'type': 'datetimerange', 'start': '2020-07-23 12:00:00', 'end': '2020-07-23 16:00:00'}]}, 'text': 'ayer pasado el mediodia', 'type_name': 'datetimeV2.datetimerange'}
Volvere a mediodia
{'start': 10, 'end': 17, 'resolution': {'values': [{'timex': 'TAF', 'type': 'timerange', 'start': '12:00:00', 'end': '16:00:00'}]}, 'text': 'mediodia', 'type_name': 'datetimeV2.timerange'}
Volvere pasado mediodia
{'start': 8, 'end': 22, 'resolution': {'values': [{'timex': 'TAF', 'type': 'timerange', 'start': '12:00:00', 'end': '16:00:00'}]}, 'text': 'pasado mediodia', 'type_name': 'datetimeV2.timerange'}
Volvere pasado el mediodia
{'start': 8, 'end': 25, 'resolution': {'values': [{'timex': 'TAF', 'type': 'timerange', 'start': '12:00:00', 'end': '16:00:00'}]}, 'text': 'pasado el mediodia', 'type_name': 'datetimeV2.timerange'}

```


